### PR TITLE
Fix transcript retrieval error for YouTube videos

### DIFF
--- a/cards/models.py
+++ b/cards/models.py
@@ -54,7 +54,7 @@ class Video(models.Model):
             video.title = details['title']
             video.channel = details['channel']
             video.duration = details['duration']
-            video.transcript = details['transcript']
+            video.transcript = details['transcript'] if details['transcript'] else "No transcript available"
             video.save()
         
         return video
@@ -75,4 +75,3 @@ class QuestionAnswer(models.Model):
     
     def __str__(self):
         return f"{self.question} - {self.answer}"
-

--- a/cards/views.py
+++ b/cards/views.py
@@ -50,6 +50,10 @@ def generate(request):
             context['qas'] = video.questionanswer_set.all()
 
         context['video'] = video
+
+        if video.transcript == "No transcript available":
+            context['error'] = "Transcript not available for this video"
+            template_name = 'cards/htmx/error.html'
     except Exception as e:
         context['error'] = str(e)
         template_name = 'cards/htmx/error.html'

--- a/y2a/clients.py
+++ b/y2a/clients.py
@@ -1,6 +1,7 @@
 from isodate import parse_duration
 import requests
 from youtube_transcript_api import YouTubeTranscriptApi
+import logging
 
 class YoutubeClient:
     def __init__(self, api_key):
@@ -12,8 +13,12 @@ class YoutubeClient:
         return r.json()
     
     def get_transcript(self, id):
-        t = YouTubeTranscriptApi.get_transcript(id)
-        return " ".join([x['text'] for x in t])
+        try:
+            t = YouTubeTranscriptApi.get_transcript(id)
+            return " ".join([x['text'] for x in t])
+        except YouTubeTranscriptApi.CouldNotRetrieveTranscript:
+            logging.warning(f"Could not retrieve transcript for video ID {id}. Subtitles might be disabled.")
+            return ""
     
     def get_details(self, id):
         data = self.get_data(id)
@@ -27,4 +32,3 @@ class YoutubeClient:
         }
         
         return details
-    


### PR DESCRIPTION
Fixes #4

Fix transcript retrieval error for YouTube videos.

* Add a try-except block in `get_transcript` method in `y2a/clients.py` to catch `YouTubeTranscriptApi.CouldNotRetrieveTranscript` exception and log a warning if subtitles are disabled.
* Modify `create_or_get_video` method in `cards/models.py` to handle empty transcripts by setting `transcript` field to "No transcript available" if the transcript is empty.
* Update error handling in `generate` view in `cards/views.py` to display a user-friendly message if transcript retrieval fails by setting `context['error']` to "Transcript not available for this video" if the transcript is "No transcript available".

Possible solution that may have caused crashes due to videos having transcript / closed captions disabled.